### PR TITLE
Adds copy image to clipboard feature

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <script src="{{ '/assets/js/image-to-clipboard.js?v=' | append: site.github.build_revision | relative_url }}"></script>
     {% include head-custom.html %}
   </head>
   <body>

--- a/assets/js/image-to-clipboard.js
+++ b/assets/js/image-to-clipboard.js
@@ -1,0 +1,6 @@
+async function copyImageToClipboard(url) {
+    console.log("copy", url);
+    const response = await fetch(url);
+    const blob = await response.blob();
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+}

--- a/index.markdown
+++ b/index.markdown
@@ -25,5 +25,5 @@ layout: default
   {% capture  img_url %}{{ site.url }}{{ site.baseurl }}/images/{{ reaction.image }}{% endcapture %}
   <input class="urltext" type="text" readonly="true" data-clipboard-text="{{img_url}}" value="{{img_url}}">
   <button title="Copy link" onclick="navigator.clipboard.writeText('{{img_url}}')"><i class="fas fa-link"></i></button>
-  <button title="Copy image" onclick="navigator.clipboard.writeText('{{img_url}}')"><i class="fas fa-copy"></i></button>
+  <button title="Copy image" onclick="copyImageToClipboard('{{img_url}}')"><i class="fas fa-copy"></i></button>
 {% endfor %}


### PR DESCRIPTION
Copies actual image to clipboard upon pressing the appropriate button.

Note: when testing locally, use `localhost` instead of `127.0.0.1` to avoid CORS errors.